### PR TITLE
Updated go.md bash example file

### DIFF
--- a/docs/technologies/go.md
+++ b/docs/technologies/go.md
@@ -90,10 +90,11 @@ const results = []
 // Loop through each line and parse it as JSON and check if it is a result line
 lines.forEach(line => {
   const output = JSON.parse(line).Output?.trim()
-  const valid = output.includes('PASS') || output.includes('FAIL')
+  if (output === undefined) return
+  const valid = output.includes("--- PASS") || output.includes("--- FAIL")
   if(!valid) return
 
-  const passed = output.includes('PASS')
+  const passed = output.includes('--- PASS')
 
   // Add the pass/fail status to the array
   results.push(passed)
@@ -102,6 +103,9 @@ lines.forEach(line => {
 // Write results
 fs.writeFileSync(process.env.UNIT_TEST_OUTPUT_FILE, JSON.stringify(results))
 EOF
+
+# removing mod.go before testing the result because if it fails we don't need to remove go.mod manually
+rm go.mod
 
 # process results
 node processGoResults.js


### PR DESCRIPTION
Test output in go is in this format.
<img width="292" alt="Screenshot 2024-01-24 at 9 51 42 PM" src="https://github.com/codedamn/teach.codedamn.com/assets/109629956/c9c1a6a7-49b6-4580-bc6a-49efa0de509f">
therefore we should be checking for `--- PASS` instead of `PASS`
if we do `PASS` then all the strings that have pass string will return `true` which is wrong

`if (output === undefined) return` when its not actual testCase structure then output is `undefined`
Idk how that works, but adding this solves the error.

`rm go.mod` removing go.mod before `node testoutput.js` because if testoutput.js fails all the test files won't get deleted and we need to manually remove go.mod.